### PR TITLE
Leaving empty desktop behavior and UI tooltips

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -33,12 +33,12 @@ ignoredClients = ignoredClients.concat(
   );
 
 // Easy way to disable all Java-based programs
-if (readConfig("ignoreJava", 0) == 1) {
+if (readConfig("ignoreJava", false)) {
   var java = "sun-awt-x11-xframepeer";
   ignoredClients.push(java);
 }
 
-var liveTiling = readConfig("liveTiling", 0);
+var liveTiling = readConfig("liveTiling", false);
 
 // KWin client.resourceClasses & client.resourceNames to which tiles are adjusted to
 var fixedClients = [
@@ -123,6 +123,8 @@ var floatY = readConfig("floatY", 0);
 if (floatY > 100 || floatY < 0) {
   floatY = 0
 }
+
+var followDesktop = readConfig("follow")
 
 var gap = readConfig("gap", 8);
 
@@ -539,7 +541,11 @@ function connectWorkspace() {
     addClient(client, true, ws.currentDesktop, ws.activeScreen);
   });
   ws.clientRemoved.connect(function(client) {
-    removeClient(client, true, client.desktop, client.screen);
+    for (var index = 0; index < 5; index++) {
+      print(followDesktop)
+      print(gap)
+    }
+    removeClient(client, followDesktop, client.desktop, client.screen);
   });
   ws.desktopPresenceChanged.connect(function(client, desk) {
     if (client && client.included) {
@@ -697,7 +703,7 @@ function addClients() {
 function connectClient(client, desk, scr) {
   client.clientStartUserMovedResized.connect(startMove);
   client.clientFinishUserMovedResized.connect(endMove);
-  if (liveTiling == 1) {
+  if (liveTiling) {
     client.clientStepUserMovedResized.connect(endMove);
   }
   client.activeChanged.connect(tileClients);
@@ -771,7 +777,7 @@ function disconnectClient(client) {
   client.included = false;
   client.clientStartUserMovedResized.disconnect(startMove);
   client.clientFinishUserMovedResized.disconnect(endMove);
-  if (liveTiling == 1) {
+  if (liveTiling) {
     client.clientStepUserMovedResized.disconnect(endMove);
   }
 }

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -21,6 +21,10 @@
       <label>Initial number of desktops</label>
       <default>2</default>
     </entry>
+    <entry name="follow" type="Bool">
+      <label>Go to the next busy desktop when the last window of a desktop is closed</label>
+      <default>true</default>
+    </entry>
     <entry name="ignoredScreens" type="string">
       <label>Ignored Screens</label>
       <default></default>
@@ -30,16 +34,16 @@
       <default></default>
     </entry>
     <entry name="ignoredActivities" type="string">
-      <label>Ignored Desktops</label>
+      <label>Ignored Activities</label>
       <default></default>
     </entry>
     <entry name="centerTo" type="int">
       <label>Tile small clients to the center of the tile instead of the center of the screen</label>
       <default>1</default>
     </entry>
-    <entry name="liveTiling" type="int">
+    <entry name="liveTiling" type="Bool">
       <label>Tile the windows live when dragging and resizing with mouse</label>
-      <default>0</default>
+      <default>false</default>
     </entry>
     <entry name="mt" type="int">
       <label>Top margin</label>
@@ -61,9 +65,9 @@
   	  <label>Programs that should be ignored by the script (f.ex. "kate", "steam")</label>
   	  <default>wine, steam, kate</default>
     </entry>
-    <entry name="ignoreJava" type="int">
+    <entry name="ignoreJava" type="Bool">
       <label>Ignores all Java programs if set to true</label>
-      <default>0</default>
+      <default>false</default>
     </entry>
     <entry name="ignoredCaptions" type="string">
   	  <label>(Parts of) Window captions that should be ignored by the script (f.ex "move to trash")</label>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>341</width>
-    <height>559</height>
+    <width>360</width>
+    <height>629</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -87,6 +87,9 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QLabel" name="gapLabel">
+         <property name="toolTip">
+          <string>Pixels between the windows and screen edges</string>
+         </property>
          <property name="text">
           <string>&lt;b&gt;Gap Size:&lt;/b&gt;</string>
          </property>
@@ -99,6 +102,9 @@
            <width>64</width>
            <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>Pixels between the windows and screen edges</string>
          </property>
          <property name="text">
           <string>10</string>
@@ -120,6 +126,9 @@
        </item>
        <item>
         <widget class="QLabel" name="numDesksLabel">
+         <property name="toolTip">
+          <string>Initial number of desktops</string>
+         </property>
          <property name="text">
           <string>&lt;b&gt;Initial Desktops:&lt;/b&gt;</string>
          </property>
@@ -132,6 +141,9 @@
            <width>64</width>
            <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>Initial number of desktops</string>
          </property>
          <property name="text">
           <string>2</string>
@@ -160,6 +172,9 @@
       <layout class="QHBoxLayout" name="horizontalLayout_7">
        <item>
         <widget class="QLabel" name="floatX_label">
+         <property name="toolTip">
+          <string>Floating Windows preset horizontal size value in percentage representing factor of screen size, zero disables the feature</string>
+         </property>
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Float Width&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
@@ -172,6 +187,9 @@
            <width>64</width>
            <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>Floating Windows preset horizontal size value in percentage representing factor of screen size, zero disables the feature</string>
          </property>
          <property name="text">
           <string>0</string>
@@ -193,6 +211,9 @@
        </item>
        <item>
         <widget class="QLabel" name="floatY_label">
+         <property name="toolTip">
+          <string>Floating Windows preset vertical size value in percentage representing factor of screen size, zero disables the feature</string>
+         </property>
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Float Height&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
@@ -205,6 +226,9 @@
            <width>64</width>
            <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>Floating Windows preset vertical size value in percentage representing factor of screen size, zero disables the feature</string>
          </property>
          <property name="text">
           <string>0</string>
@@ -236,6 +260,9 @@
        </property>
        <item>
         <widget class="QLabel" name="label_7">
+         <property name="toolTip">
+          <string>Tile small clients to the center of the tile or center of the screen</string>
+         </property>
          <property name="text">
           <string>&lt;b&gt;Center:&lt;/b&gt;</string>
          </property>
@@ -243,6 +270,9 @@
        </item>
        <item>
         <widget class="QComboBox" name="kcfg_centerTo">
+         <property name="toolTip">
+          <string>Tile small clients to the center of the tile or center of the screen</string>
+         </property>
          <property name="currentText">
           <string>Screen</string>
          </property>
@@ -272,34 +302,64 @@
         </spacer>
        </item>
        <item>
-        <widget class="QLabel" name="liveTilingLabel">
+        <widget class="QCheckBox" name="kcfg_follow">
+         <property name="toolTip">
+          <string>Go to the next busy desktop when the last window of a desktop is closed</string>
+         </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Live
-           Tiling&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-          </string>
+          <string>Follow</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="kcfg_liveTiling">
-         <property name="maximumSize">
+        <spacer name="horizontalSpacer_28">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
           <size>
-           <width>64</width>
-           <height>16777215</height>
+           <width>40</width>
+           <height>20</height>
           </size>
          </property>
-         <item>
-          <property name="text">
-           <string>False</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>True</string>
-          </property>
-         </item>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="kcfg_liveTiling">
+         <property name="toolTip">
+          <string>Tile the windows live when dragging and resizing with mouse</string>
+         </property>
+         <property name="text">
+          <string>Live Tiling</string>
+         </property>
         </widget>
        </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_9">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
       </layout>
      </item>
      <item>
@@ -704,26 +764,6 @@
          </property>
         </spacer>
        </item>
-       <item>
-        <widget class="QLabel" name="ignoreJavaLabel">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Java&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_16">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </item>
      <item>
@@ -752,6 +792,9 @@
            <height>16777215</height>
           </size>
          </property>
+         <property name="toolTip">
+          <string>Ignored Activities</string>
+         </property>
          <property name="placeholderText">
           <string>1, 2 ,3</string>
          </property>
@@ -777,6 +820,9 @@
            <width>64</width>
            <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>Ignored Desktops</string>
          </property>
          <property name="placeholderText">
           <string>1, 2, 3</string>
@@ -804,6 +850,9 @@
            <height>16777215</height>
           </size>
          </property>
+         <property name="toolTip">
+          <string>Ignored Screens</string>
+         </property>
          <property name="placeholderText">
           <string>1, 2, 3</string>
          </property>
@@ -822,28 +871,51 @@
          </property>
         </spacer>
        </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_9">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_10">
        <item>
-        <widget class="QComboBox" name="kcfg_ignoreJava">
-         <property name="maximumSize">
+        <spacer name="horizontalSpacer_16">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
           <size>
-           <width>64</width>
-           <height>16777215</height>
+           <width>10</width>
+           <height>20</height>
           </size>
          </property>
-         <item>
-          <property name="text">
-           <string>False</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>True</string>
-          </property>
-         </item>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="kcfg_ignoreJava">
+         <property name="toolTip">
+          <string>Ignores all Java programs if checked</string>
+         </property>
+         <property name="text">
+          <string>Java</string>
+         </property>
         </widget>
        </item>
        <item>
-        <spacer name="horizontalSpacer_21">
+        <spacer name="horizontalSpacer_30">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
@@ -953,6 +1025,9 @@
        </property>
        <item>
         <widget class="QLineEdit" name="kcfg_ignoredClients">
+         <property name="toolTip">
+          <string>Ignored Programs (Separated by ',')</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -963,6 +1038,9 @@
        </item>
        <item>
         <widget class="QLineEdit" name="kcfg_ignoredCaptions">
+         <property name="toolTip">
+          <string>(Parts of) Window captions that should be ignored by the script (f.ex &quot;move to trash&quot;) (separated by ',')</string>
+         </property>
          <property name="text">
           <string/>
          </property>
@@ -1035,6 +1113,9 @@
        </property>
        <item>
         <widget class="QLineEdit" name="kcfg_fixedClients">
+         <property name="toolTip">
+          <string>Clients that are aligned (position) but not resized with the layout (separated by ',')</string>
+         </property>
          <property name="text">
           <string>telegram, telegramdesktop, telegram-desktop</string>
          </property>


### PR DESCRIPTION
Hey man its me again,
The behavior when you leave a desktop if all the windows on it were closed is useful, but sometimes its annoying if you have floating windows. I decided to make a setting for it that will stop the script from leaving the desktop when you close a window. However, I wanted to make it as a checkbox (and I also made "ignoreJava" and "liveTiling" as a checkbox) However I'm not able to extract the boolean value out of it. It seems to always return true even though the checkbox in unchecked. 

I've found checkbox implemented on this other tiling script ([code](https://github.com/faho/kwin-tiling/blob/364255929f5f7742cef23cfc7203df10495d6848/contents/code/tile.js#L111) and [config xml](https://github.com/faho/kwin-tiling/blob/364255929f5f7742cef23cfc7203df10495d6848/contents/config/main.xml#L12)), and I saw the same thing on some examples that KDE has online [here](https://cgit.kde.org/kdeexamples.git/tree/kconfigxt/example.kcfg#n12).

But they don't seem to work... Do you have any clue about why this is happening and if we could make this work?
I don't know how to debug this, the only way I can get the output from running the script is wih KWin interactive console, but that seems to only run the script and ignore the configurations...

Also I added the tooltips from the config XML file to the UI so that the options are easier to interpret.
